### PR TITLE
🐛 fix: add User-Agent header to HTTP requests

### DIFF
--- a/calibre-web/moly_hu.py
+++ b/calibre-web/moly_hu.py
@@ -47,7 +47,7 @@ def parse_languages(langs, locale: str) -> List[str]:
 
 
 def fetch_page(page):
-    return requests.get(page).text
+    return requests.get(page, headers={"User-Agent": "Mozilla/5.0 (compatible; CalibreWeb/1.0)"}).text
 
 
 class Molyhu(Metadata):

--- a/moly_hu/main.py
+++ b/moly_hu/main.py
@@ -13,7 +13,9 @@ if __name__ == "__main__":
     search_for = args.search_for
     max_result = args.count
 
-    browser = lambda url: urllib.request.urlopen(url).read().decode("utf-8")
+    browser = lambda url: urllib.request.urlopen(
+        urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; CalibreMolyhu/1.0)"})
+    ).read().decode("utf-8")
 
     book_ids = molyhu.search(search_for, browser)
     for count, book_id in enumerate(book_ids, start=1):


### PR DESCRIPTION
## Problem

moly.hu recently started rejecting HTTP requests that use default library User-Agent strings (e.g. `python-requests/x.x.x` or `Python-urllib/3.x`), returning HTTP 403 Forbidden. This causes all metadata searches in Calibre-Web to return empty results.

**Affected components:**
- `calibre-web/moly_hu.py` — `fetch_page()` uses `requests.get()` without User-Agent
- `moly_hu/main.py` — CLI tool uses `urllib.request.urlopen()` without User-Agent

**Not affected:**
- `calibre/__init__.py` — uses Calibre's built-in `browser()` which sends a proper User-Agent

## Evidence

Tested from inside the Calibre-Web container:

```
# Without User-Agent → blocked
>>> requests.get('https://moly.hu/kereses?query=...').status_code
403

# With User-Agent → works
>>> requests.get('https://moly.hu/kereses?query=...', headers={'User-Agent': 'Mozilla/5.0 ...'}).status_code
200
```

CWA logs showing the issue:
```
INFO {cps.metadata_provider.moly_hu:67} Query: Trópusi pokol
INFO {cps.metadata_provider.moly_hu:70} Found book ids: set()
```

## Fix

Add a User-Agent header to all HTTP requests in both `calibre-web/moly_hu.py` and `moly_hu/main.py`.
